### PR TITLE
giving possibility to maintain multiple selection on mouseHouver

### DIFF
--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -299,7 +299,7 @@ class MVTSource {
     }
 
     onMouseHover(event, callbackFunction, options) {
-        this._multipleSelection = false;
+        this._multipleSelection = (options && options.multipleSelection) || false;
         options = this._getMouseOptions(options, true);
         this._mouseEvent(event, callbackFunction, options);
     }


### PR DESCRIPTION
Closes [#11](https://github.com/techjb/Vector-Tiles-Google-Maps/issues/11)
Copy of the code of onClick in onMouseHover regarding multipleSelection in order for it not to be set systematically to false and losing multiple selection when refresh.
I would have personally removed this line as I dont see why mousehover should impact multipleSelection but this way I'm sure anything remains possible as might have been intended.