### PR TITLE
Improve tile cache performance for vector tiles

### DIFF
--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -1,5 +1,5 @@
 /*
- *  Created by Jesús Barrio on 04/2021
+ *  Created by JesÃºs Barrio on 04/2021
  */
 
 const TWO_PI = Math.PI * 2;
@@ -25,8 +25,9 @@ class MVTFeature {
         this.tiles[tileContext.id] = {
             vectorTileFeature: vectorTileFeature,
             divisor: vectorTileFeature.extent / tileContext.tileSize,
-            context2d: false,
-            paths2d: false
+            context2d: null,
+            paths2d: null,
+            paths: null
         };
     }
 
@@ -141,6 +142,9 @@ class MVTFeature {
     }
 
     drawCoordinates(tileContext, tile) {
+        if (tile.paths2d) {
+            return;
+        }
         const coordinates = tile.vectorTileFeature.coordinates;
         const divisor = tile.divisor;
         const paths2d = new Path2D();
@@ -168,6 +172,9 @@ class MVTFeature {
 
     getPaths(tileContext) {
         const tile = this.tiles[tileContext.id];
+        if (tile.paths) {
+            return tile.paths;
+        }
         const coordinates = tile.vectorTileFeature.coordinates;
         const divisor = tile.divisor;
         const coordsLength = coordinates.length;
@@ -189,7 +196,8 @@ class MVTFeature {
         }
 
         paths.length = pathCount; // Trim array to actual size
-        return paths;
+        tile.paths = paths;
+        return tile.paths;
     }
 
     getContext2d(canvas, style) {

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -54,9 +54,9 @@ class MVTSource {
         this._customDraw = options.customDraw || false;
 
         this.mVTLayers = [];  //Keep a list of the layers contained in the PBFs        
-        this._tilesDrawn = []; //  List of tiles drawn  (when cache enabled)
-        this._visibleTiles = []; // tiles currently in the viewport        
-        this._selectedFeatures = []; // list of selected features
+        this._tilesDrawn = Object.create(null); //  List of tiles drawn  (when cache enabled)
+        this._visibleTiles = Object.create(null); // tiles currently in the viewport        
+        this._selectedFeatures = Object.create(null); // list of selected features
         this.loadedTilesLen = 0; // total number of loaded tiles
 
         if (options.selectedFeatures) {
@@ -94,7 +94,7 @@ class MVTSource {
     }
 
     _resetVisibleTiles() {
-        this._visibleTiles = [];
+        this._visibleTiles = Object.create(null);
     }
 
     _setVisibleTile(tileContext) {
@@ -232,7 +232,7 @@ class MVTSource {
     }
 
     _resetTileDrawn() {
-        this._tilesDrawn = [];
+        this._tilesDrawn = Object.create(null);
     }
 
     _drawVectorTile(vectorTile, tileContext) {
@@ -403,7 +403,7 @@ class MVTSource {
             }
         }        
         this.redrawTiles(tilesToRedraw);
-        this._selectedFeatures = [];
+        this._selectedFeatures = Object.create(null);
     }
 
     featureSelected(mVTFeature) {


### PR DESCRIPTION
### Motivation
- Reduce redundant geometry work and hit-test cost by caching per-tile Path2D and path arrays.  
- Improve lookup/reset performance for tile and selection caches by using null-prototype maps instead of arrays.

### Description
- Replace array-backed caches in `MVTSource` with null-prototype maps: `_tilesDrawn`, `_visibleTiles`, and `_selectedFeatures` are now created with `Object.create(null)` and reset accordingly.  
- Ensure `_resetVisibleTiles` and `_resetTileDrawn` reinitialize the caches as null-prototype maps.  
- In `MVTFeature`, replace `context2d`/`paths2d` boolean flags with `null` and add a `paths` field to store computed plain-coordinate path arrays.  
- Short-circuit `drawCoordinates` when `paths2d` already exists and cache the result of `getPaths` into `tile.paths` to avoid recomputing geometry for repeated draws and hit-tests.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69817f30ab88833289bf4acb58418b02)